### PR TITLE
Added buildpacks file for invalid dokku installations

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,0 +1,1 @@
+https://github.com/heroku/heroku-buildpack-php.git


### PR DESCRIPTION
Required for dokku because the default PHP buildpack has an invallid url for downloading PHP